### PR TITLE
Feature/type filtering

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "repo-data",
   "version": "0.1.0",
   "private": true,
+  "main": "public/index.html",
   "dependencies": {
     "core-decorators": "^0.20.0",
     "immutable": "^3.8.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "repo-data",
   "version": "0.1.0",
   "private": true,
-  "main": "public/index.html",
+  "main": "./src/index.js",
   "dependencies": {
     "core-decorators": "^0.20.0",
     "immutable": "^3.8.2",

--- a/src/App.css
+++ b/src/App.css
@@ -12,6 +12,11 @@
 }
 
 .App-wrap {
-  max-width: 700px;
+  max-width: 680px;
   margin: 10px auto;
+}
+.flex-wrap {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }

--- a/src/RepoIssues/components/IssuesApp.jsx
+++ b/src/RepoIssues/components/IssuesApp.jsx
@@ -7,6 +7,8 @@ import Subheader from 'material-ui/Subheader';
 import IssueList from './IssueList';
 import IssueDetail from './IssueDetail';
 import Visibility from 'material-ui/svg-icons/action/visibility';
+import DropDownMenu from 'material-ui/DropDownMenu';
+import MenuItem from 'material-ui/MenuItem';
 
 const IssuesApp = props => {
   const {
@@ -20,7 +22,9 @@ const IssuesApp = props => {
     repo,
     selectedIssueData,
     selectedIssueUrl,
-    issueDetailsOpen
+    issueDetailsOpen,
+    filterValue,
+    handleFilterChange
   } = props;
 
   const issueNumber = selectedIssueData.number ? selectedIssueData.number : "";
@@ -33,9 +37,6 @@ const IssuesApp = props => {
       marginTop: '-1px'
     }
   }
-
-  // const issuesFiled = issues.filter(x => !x.issueData.isPR);
-  // const prsFiled = issues.filter(x => x.issueData.isPR);
 
   return (
     <MuiThemeProvider>
@@ -57,18 +58,28 @@ const IssuesApp = props => {
               <RaisedButton label="Get issues" secondary={true} type="submit" />
             </form>
           </header>
-          <div className="App-wrap App-header">
+          <div className="App-wrap App-header flex-wrap">
+            <div>
             <RaisedButton
+                  style={{}}
                   disabled={isDisabled}
                   onClick={toggleIssueDetails}
                   label={`View ${type} ${issueNumber} Details`}
                   labelPosition="after"
                   primary={true}
                   icon={<Visibility style={styles.icon} />} />
+            </div>
+            <div>
+              <DropDownMenu value={filterValue} onChange={handleFilterChange}>
+                <MenuItem value={1} primaryText="Issues and Pull Requests" />
+                <MenuItem value={2} primaryText="Issues only" />
+                <MenuItem value={3} primaryText="Pull Requests only" />
+              </DropDownMenu>
+            </div>
           </div>
           <div className="App-wrap">
             <List className="issue-list">
-              <Subheader>The latest <strong>{username}/{repo}</strong> repo PRs and issues with comments</Subheader>
+              <Subheader>The latest <strong>{username}/{repo}</strong> repo data with comments</Subheader>
               <IssueList 
                 issues={issues}
                 loading={loading}

--- a/src/RepoIssues/containers/index.js
+++ b/src/RepoIssues/containers/index.js
@@ -16,6 +16,7 @@ class Main extends React.Component {
     super(props);
     this.state = {
       issues: [],
+      originalIssues: [],
       username: 'facebook',
       repo: 'react',
       loading: false,
@@ -23,7 +24,8 @@ class Main extends React.Component {
       selectedIssueData: {},
       selectedIssueUrl: '',
       selectedIssueId: '',
-      issueDetailsOpen: false
+      issueDetailsOpen: false,
+      filterValue: 1
     }
   }
 
@@ -56,12 +58,22 @@ class Main extends React.Component {
     });
   }
   toggleIssueDetails = e => this.setState({issueDetailsOpen: !this.state.issueDetailsOpen});
+  handleFilterChange = (e, index, value) => {
+    // reset selected state & need to store the filter value
+    this.setState({filterValue: value, selectedIssueUrl: '', selectedIssueData: {}});
+    if (value === 2) {
+      this.setState({issues: this.issuesFiled});
+    } else if (value === 3) {
+      this.setState({issues: this.prsFiled});
+    } else {
+      this.setState({issues: this.state.originalIssues});
+    }
+  }
 
   /* 
    * data processing functions
    */
   displayIssues = () => {
-    this.props.actions.loadIssueList(this.state);
     RepoIssueService.getIssues(this.state, response => {
       const {issues, error} = response;
       const issuesResponse = error ? this.setState({error, loading: false}) : this.processIssues(issues);
@@ -86,7 +98,9 @@ class Main extends React.Component {
       }
       return data;
     });
-    this.setState({issues, loading: false})
+    this.issuesFiled = issues.filter(x => !x.issueData.isPR); // we need an array of issues only
+    this.prsFiled = issues.filter(x => x.issueData.isPR); // we need an array of PRs only
+    this.setState({issues, originalIssues: issues, loading: false, filterValue: 1})
   }
 
   render() {
@@ -102,7 +116,9 @@ class Main extends React.Component {
       selectedIssueData: this.state.selectedIssueData,
       selectedIssueUrl: this.state.selectedIssueUrl,
       selectedIssueId: this.state.selectedIssueId,
-      issueDetailsOpen: this.state.issueDetailsOpen
+      issueDetailsOpen: this.state.issueDetailsOpen,
+      filterValue: this.state.filterValue,
+      handleFilterChange: this.handleFilterChange
     }
     return IssuesApp(props);
   }


### PR DESCRIPTION
## Summary
This PR adds issue type filtering. The GitHub issues api returns a list of both issues and PRs. Filtering is now added via a material-ui drop down menu at the top right of the list.
### Files changed
- `IssuesApp.jsx` - Main presenter is updated to use `DropDownMenu` and `MenuItem` from material-ui as well as 3 new props: `issueDetailsOpen`, `filterValue`, and `handleFilterChange`.
- `index.js` - Main container is updated with a `handleFilterChange` function, new filtered list variables, and 2 new additions to state.
- `App.css` - Styling changes
### Filtering
I'm creating two filtered arrays (`issuesFiled`, `prsFiled`) when I fetch:
```
this.issuesFiled = issues.filter(x => !x.issueData.isPR); // we need an array of issues only
this.prsFiled = issues.filter(x => x.issueData.isPR); // we need an array of PRs only
```
then setting the issues state to those when filtering is triggered. I decided to store an original array of all PRs and Issues together when I fetch from the api. Then I could just set the state of the issues state array to `this.state.originalIssues` when a user selected "All" from the filter drop down:
```
  handleFilterChange = (e, index, value) => {
    // reset selected state & need to store the filter value
    this.setState({filterValue: value, selectedIssueUrl: '', selectedIssueData: {}});
    if (value === 2) {
      this.setState({issues: this.issuesFiled});
    } else if (value === 3) {
      this.setState({issues: this.prsFiled});
    } else {
      this.setState({issues: this.state.originalIssues});
    }
  }
```
### Screenshots
![repo-issues-type-filtering](https://user-images.githubusercontent.com/104025/36843651-2f1b882a-1d15-11e8-9075-7294649f8258.gif)
